### PR TITLE
feat(pi-powerline): match Claude branch pill — show +N ~N counts

### DIFF
--- a/stow/pi/.pi/agent/extensions/powerline/index.ts
+++ b/stow/pi/.pi/agent/extensions/powerline/index.ts
@@ -1,14 +1,20 @@
 import type { ExtensionAPI } from "@mariozechner/pi-coding-agent"
-import { render as powerline, State } from "./render.ts"
+import { render as powerline } from "./render.ts"
+import type { State } from "./render.ts"
 import { execSync } from "node:child_process"
 
-function gitInfo(dir: string): { branch: string | null; dirty: boolean } {
+function gitInfo(dir: string): { branch: string | null; staged: number; modified: number } {
   try {
-    const branch = execSync("git branch --show-current", { cwd: dir, encoding: "utf8" }).trim()
-    const status = execSync("git status --porcelain",    { cwd: dir, encoding: "utf8" }).trim()
-    return { branch: branch || null, dirty: status.length > 0 }
+    const branch   = execSync("git branch --show-current",      { cwd: dir, encoding: "utf8" }).trim()
+    const stagedRaw = execSync("git diff --cached --numstat",   { cwd: dir, encoding: "utf8" }).trim()
+    const modRaw    = execSync("git diff --numstat",            { cwd: dir, encoding: "utf8" }).trim()
+    return {
+      branch:   branch || null,
+      staged:   stagedRaw  ? stagedRaw.split("\n").length  : 0,
+      modified: modRaw     ? modRaw.split("\n").length     : 0,
+    }
   } catch {
-    return { branch: null, dirty: false }
+    return { branch: null, staged: 0, modified: 0 }
   }
 }
 
@@ -17,7 +23,8 @@ export default function powerlineExtension(pi: ExtensionAPI) {
     model: "",
     thinking: null,
     branch: null,
-    dirty: false,
+    staged: 0,
+    modified: 0,
     activeTool: null,
     activeAgent: null,
     activeCommand: null,
@@ -43,9 +50,10 @@ export default function powerlineExtension(pi: ExtensionAPI) {
       const level    = (ctx as any).session?.state?.thinkingLevel
       state.thinking = (level && level !== "off") ? String(level) : null
       const dir      = (ctx as any).session?.directory ?? process.cwd()
-      const git      = gitInfo(dir)
+      const git        = gitInfo(dir)
       state.branch   = git.branch
-      state.dirty    = git.dirty
+      state.staged   = git.staged
+      state.modified = git.modified
 
       // Replace the native footer entirely
       ctx.ui.setFooter((tuiArg, _theme, _footerData) => {
@@ -96,9 +104,10 @@ export default function powerlineExtension(pi: ExtensionAPI) {
       }
       state.activeCommand = null  // command completed with this turn
       const dir  = (ctx as any).session?.directory ?? process.cwd()
-      const git  = gitInfo(dir)
-      state.branch = git.branch
-      state.dirty  = git.dirty
+      const git      = gitInfo(dir)
+      state.branch   = git.branch
+      state.staged   = git.staged
+      state.modified = git.modified
       requestRender()
     } catch { /* never crash the session */ }
   })

--- a/stow/pi/.pi/agent/extensions/powerline/render.test.ts
+++ b/stow/pi/.pi/agent/extensions/powerline/render.test.ts
@@ -1,12 +1,14 @@
 import { test } from "node:test"
 import assert from "node:assert/strict"
-import { render, State } from "./render.ts"
+import { render } from "./render.ts"
+import type { State } from "./render.ts"
 
 const baseState: State = {
   model: "Sonnet 4.6",
   thinking: null,
   branch: "main",
-  dirty: false,
+  staged: 0,
+  modified: 0,
   activeTool: null,
   activeAgent: null,
   activeCommand: null,
@@ -74,8 +76,26 @@ test("render hides git segment when branch is null", () => {
 
 test("render produces different output when dirty", () => {
   const clean = render(baseState)
-  const dirty = render({ ...baseState, dirty: true })
+  const dirty = render({ ...baseState, staged: 2, modified: 3 })
   assert.notEqual(clean, dirty)
+})
+
+test("render shows staged and modified counts when dirty", () => {
+  const result = render({ ...baseState, staged: 2, modified: 3 })
+  assert.ok(result.includes("+2"))
+  assert.ok(result.includes("~3"))
+})
+
+test("render shows only staged count when no modified", () => {
+  const result = render({ ...baseState, staged: 1, modified: 0 })
+  assert.ok(result.includes("+1"))
+  assert.ok(!result.includes("~"))
+})
+
+test("render shows only modified count when no staged", () => {
+  const result = render({ ...baseState, staged: 0, modified: 4 })
+  assert.ok(!result.includes("+"))
+  assert.ok(result.includes("~4"))
 })
 
 test("render includes token counts", () => {

--- a/stow/pi/.pi/agent/extensions/powerline/render.ts
+++ b/stow/pi/.pi/agent/extensions/powerline/render.ts
@@ -22,7 +22,8 @@ export interface State {
   model: string
   thinking: string | null      // null = off/hidden (e.g. "medium", "high")
   branch: string | null
-  dirty: boolean
+  staged: number
+  modified: number
   activeTool: string | null    // null = segment hidden
   activeAgent: string | null   // null = segment hidden
   activeCommand: string | null // null = segment hidden (e.g. "/effort", "/chain")
@@ -69,8 +70,11 @@ export function render(state: State): string {
 
   // Git — conditional on branch being known
   if (state.branch !== null) {
-    const color   = state.dirty ? C.yellow : C.green
-    const text    = state.dirty ? `\uE0A0 ${state.branch} ~` : `\uE0A0 ${state.branch}`
+    const dirty = state.staged > 0 || state.modified > 0
+    const color = dirty ? C.yellow : C.green
+    let text = `\uE0A0 ${state.branch}`
+    if (state.staged   > 0) text += ` +${state.staged}`
+    if (state.modified > 0) text += ` ~${state.modified}`
     const [s, fg] = seg(lastFg, color, text)
     line += s; lastFg = fg
   }


### PR DESCRIPTION
## Summary

- Replaces `dirty: boolean` in `State` with `staged: number` / `modified: number`
- Updates `gitInfo()` to use `git diff --cached --numstat` and `git diff --numstat` (file counts) instead of `git status --porcelain`
- Branch pill now shows `+N` for staged and `~N` for modified files — identical to the Claude statusline behavior — with yellow pill when either count > 0
- Fixes `import type { State }` so `--experimental-strip-types` tests pass
- Adds 3 new render tests covering staged-only, modified-only, and both cases (20/20 passing)

## Test plan

- [ ] `node --experimental-strip-types --test render.test.ts` passes (20/20)
- [ ] Pi branch pill shows `main` (green) on clean repo
- [ ] Pi branch pill shows `main +2` (yellow) with staged files
- [ ] Pi branch pill shows `main ~3` (yellow) with modified files
- [ ] Pi branch pill shows `main +1 ~2` (yellow) with both

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Git status indicator now displays the number of staged and modified changes separately instead of a simple dirty flag, providing more granular visibility into repository state.

* **Tests**
  * Updated test coverage to validate new git status display scenarios with staged and modified counts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->